### PR TITLE
Make supervisord to get PID 1

### DIFF
--- a/setup/root/init.sh
+++ b/setup/root/init.sh
@@ -44,4 +44,4 @@ chmod -R 775  /usr/lib/sonarr /usr/bin/sonarr /home/nobody
 echo "[info] Starting Supervisor..."
 
 # run supervisor
-"/usr/bin/supervisord" -c "/etc/supervisor.conf" -n
+exec /usr/bin/supervisord -c /etc/supervisor.conf -n


### PR DESCRIPTION
With this the container will stop gracefully and faster than before
because supervisord gets SIGTERM when we run `docker stop`.