### PR TITLE
A seemingly working sonarr-phantom version.

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -30,7 +30,7 @@ fi
 ####
 
 # define aur packages
-aur_packages="sonarr"
+aur_packages="sonarr-phantom"
 
 # call aur install script (arch user repo)
 source /root/aur.sh

--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -4,4 +4,4 @@
 export XDG_CONFIG_HOME="/config/xdg"
 
 # run app
-/usr/bin/mono --debug /usr/lib/sonarr/NzbDrone.exe -nobrowser -data=/config
+/usr/bin/mono --debug /usr/lib/sonarr/Sonarr.exe -nobrowser -data=/config


### PR DESCRIPTION
Unsurprisingly, this seems to just totally work. The biggest change needed was just that the `.exe` changed from `NzbDrone.exe` to `Sonarr.exe`.

Issue #6 